### PR TITLE
Fixed bug with message "Cannot resolve module 'react-i18next/lib'"

### DIFF
--- a/src/components/auth/login.js
+++ b/src/components/auth/login.js
@@ -2,7 +2,7 @@ import { createValidator, required } from '../../utils/validation'
 import { Link } from 'react-router'
 import { reduxForm } from 'redux-form'
 import React, { PropTypes, Component } from 'react'
-import { translate } from 'react-i18next/lib'
+import { translate } from 'react-i18next'
 
 
 const validate = createValidator({

--- a/src/components/auth/register.js
+++ b/src/components/auth/register.js
@@ -2,7 +2,7 @@ import React, { PropTypes, Component } from 'react'
 import { Link } from 'react-router'
 import { reduxForm } from 'redux-form'
 import { createValidator, required, maxLength, minLength } from '../../utils/validation'
-import { translate } from 'react-i18next/lib'
+import { translate } from 'react-i18next'
 
 const validate = createValidator({
   username: [required, minLength(2), maxLength(10)],

--- a/src/components/common/header.js
+++ b/src/components/common/header.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, Component } from 'react'
-import { translate } from 'react-i18next/lib'
+import { translate } from 'react-i18next'
 import { Link } from 'react-router'
 
 export class Header extends Component {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { render } from 'react-dom'
 import { Provider } from 'react-redux'
 import { Router, createRoutes, browserHistory } from 'react-router'
 import configureStore from './store/configureStore'
-import { I18nextProvider } from 'react-i18next/lib' // as we build ourself via webpack
+import { I18nextProvider } from 'react-i18next' // as we build ourself via webpack
 import i18n from './utils/i18n'
 import rawRoutes from './routes'
 

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -1,4 +1,4 @@
-import i18n from 'i18next/lib'
+import i18n from 'i18next'
 import XHR from 'i18next-xhr-backend/lib'
 import LanguageDetector from 'i18next-browser-languagedetector/lib'
 


### PR DESCRIPTION
When I try to run it through  `npm start` I've got next errors:

> ERROR in ./src/index.js
Module not found: Error: Cannot resolve module 'react-i18next/lib' in /Users/admin/Documents/iHub JS/reduxBaseApp/src
 @ ./src/index.js 23:11-39

> ERROR in ./src/utils/i18n.js
Module not found: Error: Cannot resolve module 'i18next/lib' in /Users/admin/Documents/iHub JS/reduxBaseApp/src/utils
 @ ./src/utils/i18n.js 7:11-33

> ERROR in ./src/components/common/header.js
Module not found: Error: Cannot resolve module 'react-i18next/lib' in /Users/admin/Documents/iHub JS/reduxBaseApp/src/components/common
 @ ./src/components/common/header.js 18:11-39

> ERROR in ./src/components/auth/login.js
Module not found: Error: Cannot resolve module 'react-i18next/lib' in /Users/admin/Documents/iHub JS/reduxBaseApp/src/components/auth
 @ ./src/components/auth/login.js 26:11-39

> ERROR in ./src/components/auth/register.js
Module not found: Error: Cannot resolve module 'react-i18next/lib' in /Users/admin/Documents/iHub JS/reduxBaseApp/src/components/auth
 @ ./src/components/auth/register.js 26:11-39

A cursory look at React-i18next module shown that it doesn't contain lib directory now. So it was fixed in the source code.